### PR TITLE
Added commit option, set to default when creating and editing an entity

### DIFF
--- a/services/generic/accounts_app/custom_user_service.py
+++ b/services/generic/accounts_app/custom_user_service.py
@@ -8,14 +8,18 @@ class CustomUserService(CustomUserInterface):
                            last_name: str,
                            username: str,
                            email: str,
-                           password: str) -> CustomUser:
+                           password: str,
+                           commit=True) -> CustomUser:
 
         user = CustomUser.objects.create_user(first_name=first_name,
                                               last_name=last_name,
                                               username=username,
                                               email=email,
                                               password=password)
-        user.save()
+
+        if commit:
+            user.save()
+
         return user
 
     @staticmethod
@@ -37,7 +41,8 @@ class CustomUserService(CustomUserInterface):
                         last_name: str,
                         username: str,
                         email: str,
-                        password: str) -> CustomUser:
+                        password: str,
+                        commit=True) -> CustomUser:
         
         user = CustomUserService.get_user_by_id(_id=_id)
 
@@ -45,6 +50,7 @@ class CustomUserService(CustomUserInterface):
         user.email = email
         user.password = password
 
-        user.save()
+        if commit:
+            user.save()
 
         return user

--- a/services/generic/accounts_app/profile_service.py
+++ b/services/generic/accounts_app/profile_service.py
@@ -8,7 +8,8 @@ class ProfileService(ProfileInterface):
     def create_profile(user: CustomUser,
                        job_title: str,
                        description: str,
-                       image_path: str):
+                       image_path: str,
+                       commit=True):
 
         profile = Profile.objects.create(
             user=user,
@@ -17,7 +18,9 @@ class ProfileService(ProfileInterface):
             image=image_path
         )
 
-        profile.save()
+        if commit:
+            profile.save()
+
         return profile
 
     @staticmethod
@@ -42,7 +45,8 @@ class ProfileService(ProfileInterface):
     def edit_profile_by_id(_id: int,
                            job_title: str,
                            description: str,
-                           image_path: str):
+                           image_path: str,
+                           commit=True):
 
         profile = ProfileService.get_profile_by_id(_id=_id)
 
@@ -50,5 +54,7 @@ class ProfileService(ProfileInterface):
         profile.description = description
         profile.image_path = image_path
 
-        profile.save()
+        if commit:
+            profile.save()
+
         return profile

--- a/services/generic/application_app/application_service.py
+++ b/services/generic/application_app/application_service.py
@@ -11,7 +11,8 @@ class ApplicationService(ApplicationInterface):
     def create_application(profile: Profile,
                            listing: Listing,
                            content_type: ContentType,
-                           object_id: int) -> Application:
+                           object_id: int,
+                           commit=True) -> Application:
 
         application = Application.objects.create(
             is_approved=False,
@@ -21,7 +22,9 @@ class ApplicationService(ApplicationInterface):
             object_id=object_id
         )
 
-        application.save()
+        if commit:
+            application.save()
+
         return application
 
     @staticmethod
@@ -45,7 +48,8 @@ class ApplicationService(ApplicationInterface):
     def edit_application_by_id(_id: int,
                                profile: Profile,
                                listing: Listing,
-                               content_type: ContentType):
+                               content_type: ContentType,
+                               commit=True):
 
         application = ApplicationService.get_application_by_id(_id=_id)
 
@@ -53,6 +57,8 @@ class ApplicationService(ApplicationInterface):
         application.listing = listing
         application.content_type = content_type
 
-        application.save()
+        if commit:
+            application.save()
+
         return application
 

--- a/services/generic/application_app/job_offer_details_service.py
+++ b/services/generic/application_app/job_offer_details_service.py
@@ -4,9 +4,11 @@ from services.interfaces.application_app.job_offer_details_interface import JobO
 
 class JobOfferDetailsService(JobOfferDetailsInterface):
     @staticmethod
-    def create_job_offer_details(cv, motivation_letter: str) -> JobOfferDetails:
+    def create_job_offer_details(cv, motivation_letter: str, commit=True) -> JobOfferDetails:
         job_offer_details = JobOfferDetails.objects.create(cv=cv, motivation_letter=motivation_letter)
-        job_offer_details.save()
+
+        if commit:
+            job_offer_details.save()
 
         return job_offer_details
 
@@ -28,9 +30,11 @@ class JobOfferDetailsService(JobOfferDetailsInterface):
         job_offer_details.delete()
 
     @staticmethod
-    def edit_job_offer_by_id(_id: int, motivation_letter) -> JobOfferDetails:
+    def edit_job_offer_by_id(_id: int, motivation_letter, commit=True) -> JobOfferDetails:
         job_offer_details = JobOfferDetailsService.get_job_offer_details_by_id(_id=_id)
         job_offer_details.motivation_letter = motivation_letter
-        job_offer_details.save()
+
+        if commit:
+            job_offer_details.save()
 
         return job_offer_details

--- a/services/generic/application_app/project_details_service.py
+++ b/services/generic/application_app/project_details_service.py
@@ -4,9 +4,12 @@ from services.interfaces.application_app.project_details_interface import Projec
 
 class ProjectDetailsService(ProjectDetailsInterface):
     @staticmethod
-    def create_project_details(motivation_letter: str) -> ProjectDetails:
+    def create_project_details(motivation_letter: str, commit=True) -> ProjectDetails:
         project_details = ProjectDetails.objects.create(motivation_letter=motivation_letter)
-        project_details.save()
+
+        if commit:
+            project_details.save()
+
         return project_details
 
     @staticmethod
@@ -28,11 +31,13 @@ class ProjectDetailsService(ProjectDetailsInterface):
 
     @staticmethod
     def edit_project_details_by_id(_id: int,
-                                   motivation_letter: int) -> ProjectDetails:
+                                   motivation_letter: int,
+                                   commit=True) -> ProjectDetails:
         project_details = ProjectDetailsService.get_project_details_by_id(_id=_id)
-
         project_details.motivation_letter = motivation_letter
-        project_details.save()
+
+        if commit:
+            project_details.save()
 
         return project_details
 

--- a/services/generic/company_profiles_app/company_identifiers_service.py
+++ b/services/generic/company_profiles_app/company_identifiers_service.py
@@ -5,7 +5,7 @@ from services.interfaces.company_profiles_app.company_identifiers_interface impo
 
 class CompanyIdentifiersService(CompanyIdentifiersInterface):
     @staticmethod
-    def create_company_identifier(_type: str, value, company: Company) \
+    def create_company_identifier(_type: str, value, company: Company, commit=True) \
             -> CompanyIdentifiers:
 
         identifier = CompanyIdentifiers.objects.create(
@@ -13,7 +13,10 @@ class CompanyIdentifiersService(CompanyIdentifiersInterface):
             value=value,
             company=company
         )
-        identifier.save()
+
+        if commit:
+            identifier.save()
+
         return identifier
 
     @staticmethod
@@ -30,7 +33,7 @@ class CompanyIdentifiersService(CompanyIdentifiersInterface):
         identifier.delete()
 
     @staticmethod
-    def edit_identifier_by_id(_id: int, _type: str, value, company: Company) \
+    def edit_identifier_by_id(_id: int, _type: str, value, company: Company, commit=True) \
             -> CompanyIdentifiers:
 
         identifier = CompanyIdentifiersService.get_identifier_by_id(_id=_id)
@@ -38,6 +41,8 @@ class CompanyIdentifiersService(CompanyIdentifiersInterface):
         identifier.type = _type
         identifier.value = value
         identifier.company = company
-        identifier.save()
+
+        if commit:
+            identifier.save()
 
         return identifier

--- a/services/generic/company_profiles_app/company_service.py
+++ b/services/generic/company_profiles_app/company_service.py
@@ -7,7 +7,8 @@ class CompanyService(CompanyInterface):
     def create_company(address: str,
                        secondary_address: str,
                        name: str,
-                       website: str):
+                       website: str,
+                       commit=True):
 
         company = Company(
             address=address,
@@ -16,7 +17,9 @@ class CompanyService(CompanyInterface):
             website=website
         )
 
-        company.save()
+        if commit:
+            company.save()
+
         return company
 
     @staticmethod
@@ -37,7 +40,8 @@ class CompanyService(CompanyInterface):
                      address: str,
                      secondary_address: str,
                      name: str,
-                     website: str):
+                     website: str,
+                     commit=True):
 
         company = CompanyService.get_company_by_id(_id)
 
@@ -46,5 +50,7 @@ class CompanyService(CompanyInterface):
         company.name = name
         company.website = website
 
-        company.save()
+        if commit:
+            company.save()
+
         return company

--- a/services/generic/company_profiles_app/employment_service.py
+++ b/services/generic/company_profiles_app/employment_service.py
@@ -5,7 +5,7 @@ from services.interfaces.company_profiles_app.employment_interface import Employ
 
 class EmploymentService(EmploymentInterface):
     @staticmethod
-    def create_employment(profile: Profile, company: Company, job_title: str)\
+    def create_employment(profile: Profile, company: Company, job_title: str, commit=True)\
             -> Employment:
 
         employment = Employment(
@@ -15,7 +15,9 @@ class EmploymentService(EmploymentInterface):
             is_associate=False
         )
 
-        employment.save()
+        if commit:
+            employment.save()
+
         return employment
 
     @staticmethod
@@ -45,13 +47,17 @@ class EmploymentService(EmploymentInterface):
             _id: int,
             profile: Profile,
             company: Company,
-            job_title: str) -> Employment:
+            job_title: str,
+            commit=True) -> Employment:
 
         employment = EmploymentService.get_employment_by_id(_id=_id)
 
         employment.profile = profile
         employment.company = company
         employment.job_title = job_title
+
+        if commit:
+            employment.save()
 
         return employment
 

--- a/services/generic/listing_app/job_offer_service.py
+++ b/services/generic/listing_app/job_offer_service.py
@@ -14,7 +14,8 @@ class JobOfferService(JobOfferInterface):
                          key_responsibilities: str,
                          required_qualifications: str,
                          preferred_qualifications: str,
-                         remote_option: bool) -> JobOffer:
+                         remote_option: bool,
+                         commit=True) -> JobOffer:
 
         job_offer = JobOffer.objects.create(
             listing=listing,
@@ -29,7 +30,9 @@ class JobOfferService(JobOfferInterface):
             remote_option=remote_option
         )
 
-        job_offer.save()
+        if commit:
+            job_offer.save()
+
         return job_offer
 
     @staticmethod
@@ -60,8 +63,8 @@ class JobOfferService(JobOfferInterface):
                              key_responsibilities: str,
                              required_qualifications: str,
                              preferred_qualifications: str,
-                             remote_option: bool
-                             ) -> JobOffer:
+                             remote_option: bool,
+                             commit=True) -> JobOffer:
         job_offer = JobOfferService.get_job_offer_by_id(_id=_id)
 
         job_offer.listing = listing
@@ -75,6 +78,7 @@ class JobOfferService(JobOfferInterface):
         job_offer.preferred_qualifications = preferred_qualifications
         job_offer.remote_option = remote_option
 
-        job_offer.save()
+        if commit:
+            job_offer.save()
 
         return job_offer

--- a/services/generic/listing_app/listing_identifiers_service.py
+++ b/services/generic/listing_app/listing_identifiers_service.py
@@ -7,10 +7,14 @@ class ListingIdentifiersService(ListingIdentifiersInterface):
     @staticmethod
     def create_listing_identifier(_type: str,
                                   value,
-                                  listing: Listing) -> ListingIdentifiers:
+                                  listing: Listing,
+                                  commit=True) -> ListingIdentifiers:
 
         identifier = ListingIdentifiers(type=_type, value=value, listing=listing)
-        identifier.save()
+
+        if commit:
+            identifier.save()
+
         return identifier
 
     @staticmethod
@@ -30,7 +34,8 @@ class ListingIdentifiersService(ListingIdentifiersInterface):
     def edit_identifier_by_id(_id: int,
                               _type: str,
                               value,
-                              listing: Listing) -> ListingIdentifiers:
+                              listing: Listing,
+                              commit=True) -> ListingIdentifiers:
 
         identifier = ListingIdentifiersService.get_identifier_by_id(_id=_id)
 
@@ -38,5 +43,7 @@ class ListingIdentifiersService(ListingIdentifiersInterface):
         identifier.value = value
         identifier.listing = listing
 
-        identifier.save()
+        if commit:
+            identifier.save()
+
         return identifier

--- a/services/generic/listing_app/listing_service.py
+++ b/services/generic/listing_app/listing_service.py
@@ -7,7 +7,8 @@ class ListingService(ListingInterface):
     def create_listing(title: str,
                        location: str,
                        images: str,
-                       description: str) -> Listing:
+                       description: str,
+                       commit=True) -> Listing:
 
         listing = Listing.objects.create(
             title=title,
@@ -16,7 +17,9 @@ class ListingService(ListingInterface):
             description=description,
         )
 
-        listing.save()
+        if commit:
+            listing.save()
+
         return listing
 
     @staticmethod
@@ -41,7 +44,8 @@ class ListingService(ListingInterface):
                            title: str,
                            location: str,
                            images: str,
-                           description: str) -> Listing:
+                           description: str,
+                           commit=True) -> Listing:
 
         listing = ListingService.get_listing_by_id(_id)
 
@@ -50,5 +54,7 @@ class ListingService(ListingInterface):
         listing.images = images
         listing.description = description
 
-        listing.save()
+        if commit:
+            listing.save()
+
         return listing

--- a/services/generic/listing_app/project_service.py
+++ b/services/generic/listing_app/project_service.py
@@ -8,14 +8,18 @@ class ProjectService(ProjectInterface):
                        wage: int,
                        preferred_payment: str,
                        status: Project.Status,
-                       estimated_duration: str) -> Project:
+                       estimated_duration: str,
+                       commit=True) -> Project:
 
         project = Project.objects.create(listing=listing,
                                          wage=wage,
                                          preferred_payment=preferred_payment,
                                          status=status,
                                          estimated_duration=estimated_duration)
-        project.save()
+
+        if commit:
+            project.save()
+
         return project
 
     @staticmethod
@@ -40,7 +44,8 @@ class ProjectService(ProjectInterface):
                            wage: int,
                            preferred_payment: str,
                            status: Project.Status,
-                           estimated_duration: str) -> Project:
+                           estimated_duration: str,
+                           commit=True) -> Project:
 
         project = ProjectService.get_project_by_id(_id=_id)
 
@@ -49,7 +54,8 @@ class ProjectService(ProjectInterface):
         project.status = status
         project.estimated_duration = estimated_duration
 
-        project.save()
+        if commit:
+            project.save()
 
         return project
 

--- a/services/generic/shared_app/user_suggestion_service.py
+++ b/services/generic/shared_app/user_suggestion_service.py
@@ -9,7 +9,8 @@ class UserSuggestionService(UserSuggestionInterface):
     def create_user_suggestion(field_name: str,
                                suggestion: str,
                                content_type: ContentType,
-                               object_id: int) -> UserSuggestion:
+                               object_id: int,
+                               commit=True) -> UserSuggestion:
 
         user_suggestion = UserSuggestion.objects.create(
             field_name=field_name,
@@ -18,7 +19,9 @@ class UserSuggestionService(UserSuggestionInterface):
             object_id=object_id
         )
 
-        user_suggestion.save()
+        if commit:
+            user_suggestion.save()
+
         return user_suggestion
 
     @staticmethod
@@ -39,7 +42,8 @@ class UserSuggestionService(UserSuggestionInterface):
                                    field_name: str,
                                    suggestion: str,
                                    content_type: ContentType,
-                                   object_id: int) -> UserSuggestion:
+                                   object_id: int,
+                                   commit=True) -> UserSuggestion:
         user_suggestion = UserSuggestionService.get_user_suggestion_by_id(_id=_id)
 
         user_suggestion.field_name = field_name
@@ -47,5 +51,7 @@ class UserSuggestionService(UserSuggestionInterface):
         user_suggestion.content_type = content_type
         user_suggestion.object_id = object_id
 
-        user_suggestion.save()
+        if commit:
+            user_suggestion.save()
+
         return user_suggestion

--- a/services/interfaces/accounts_app/custom_user_interface.py
+++ b/services/interfaces/accounts_app/custom_user_interface.py
@@ -10,7 +10,8 @@ class CustomUserInterface(ABC):
                            last_name: str,
                            username: str,
                            email: str,
-                           password: str) -> CustomUser:
+                           password: str,
+                           commit=True) -> CustomUser:
         pass
 
     @staticmethod
@@ -35,5 +36,6 @@ class CustomUserInterface(ABC):
                         last_name: str,
                         username: str,
                         email: str,
-                        password: str) -> CustomUser:
+                        password: str,
+                        commit=True) -> CustomUser:
         pass

--- a/services/interfaces/accounts_app/profile_interface.py
+++ b/services/interfaces/accounts_app/profile_interface.py
@@ -10,7 +10,8 @@ class ProfileInterface(ABC):
     def create_profile(user: CustomUser,
                        job_title: str,
                        description: str,
-                       image_path: str):
+                       image_path: str,
+                       commit=True):
         pass
 
     @staticmethod
@@ -38,5 +39,6 @@ class ProfileInterface(ABC):
     def edit_profile_by_id(_id: int,
                            job_title: str,
                            description: str,
-                           image_path: str):
+                           image_path: str,
+                           commit=True):
         pass

--- a/services/interfaces/application_app/application_interface.py
+++ b/services/interfaces/application_app/application_interface.py
@@ -13,7 +13,8 @@ class ApplicationInterface(ABC):
     def create_application(profile: Profile,
                            listing: Listing,
                            content_type: ContentType,
-                           object_id: int) -> Application:
+                           object_id: int,
+                           commit=True) -> Application:
         pass
 
     @staticmethod
@@ -36,5 +37,6 @@ class ApplicationInterface(ABC):
     def edit_application_by_id(_id: int,
                                profile: Profile,
                                listing: Listing,
-                               content_type: ContentType):
+                               content_type: ContentType,
+                               commit=True):
         pass

--- a/services/interfaces/application_app/job_offer_details_interface.py
+++ b/services/interfaces/application_app/job_offer_details_interface.py
@@ -6,7 +6,7 @@ from application_app.models.job_offer_details import JobOfferDetails
 class JobOfferDetailsInterface(ABC):
     @staticmethod
     @abstractmethod
-    def create_job_offer_details(cv, motivation_letter: str) -> JobOfferDetails:
+    def create_job_offer_details(cv, motivation_letter: str, commit=True) -> JobOfferDetails:
         pass
 
     @staticmethod
@@ -31,5 +31,5 @@ class JobOfferDetailsInterface(ABC):
 
     @staticmethod
     @abstractmethod
-    def edit_job_offer_by_id(_id: int, motivation_letter) -> JobOfferDetails:
+    def edit_job_offer_by_id(_id: int, motivation_letter, commit=True) -> JobOfferDetails:
         pass

--- a/services/interfaces/application_app/project_details_interface.py
+++ b/services/interfaces/application_app/project_details_interface.py
@@ -6,7 +6,7 @@ from application_app.models.project_details import ProjectDetails
 class ProjectDetailsInterface(ABC):
     @staticmethod
     @abstractmethod
-    def create_project_details(motivation_letter: str) -> ProjectDetails:
+    def create_project_details(motivation_letter: str, commit=True) -> ProjectDetails:
         pass
 
     @staticmethod
@@ -32,5 +32,6 @@ class ProjectDetailsInterface(ABC):
     @staticmethod
     @abstractmethod
     def edit_project_details_by_id(_id: int,
-                                   motivation_letter: int) -> ProjectDetails:
+                                   motivation_letter: int,
+                                   commit=True) -> ProjectDetails:
         pass

--- a/services/interfaces/company_profiles_app/company_identifiers_interface.py
+++ b/services/interfaces/company_profiles_app/company_identifiers_interface.py
@@ -7,7 +7,7 @@ from company_profiles_app.models.company_identifiers import CompanyIdentifiers
 class CompanyIdentifiersInterface(ABC):
     @staticmethod
     @abstractmethod
-    def create_company_identifier(_type: str, value, company: Company) \
+    def create_company_identifier(_type: str, value, company: Company, commit=True) \
             -> CompanyIdentifiers:
         pass
 
@@ -28,6 +28,6 @@ class CompanyIdentifiersInterface(ABC):
 
     @staticmethod
     @abstractmethod
-    def edit_identifier_by_id(_id: int, _type: str, value, company: Company) \
+    def edit_identifier_by_id(_id: int, _type: str, value, company: Company, commit=True) \
             -> CompanyIdentifiers:
         pass

--- a/services/interfaces/company_profiles_app/company_interface.py
+++ b/services/interfaces/company_profiles_app/company_interface.py
@@ -9,7 +9,8 @@ class CompanyInterface(ABC):
     def create_company(address: str,
                        secondary_address: str,
                        name: str,
-                       website: str):
+                       website: str,
+                       commit=True):
         pass
 
     @staticmethod
@@ -33,5 +34,6 @@ class CompanyInterface(ABC):
                      address: str,
                      secondary_address: str,
                      name: str,
-                     website: str):
+                     website: str,
+                     commit=True):
         pass

--- a/services/interfaces/company_profiles_app/employment_interface.py
+++ b/services/interfaces/company_profiles_app/employment_interface.py
@@ -7,7 +7,7 @@ from company_profiles_app.models import Employment, Company
 class EmploymentInterface(ABC):
     @staticmethod
     @abstractmethod
-    def create_employment(profile: Profile, company: Company, job_title: str) \
+    def create_employment(profile: Profile, company: Company, job_title: str, commit=True) \
             -> Employment:
         pass
 
@@ -42,5 +42,6 @@ class EmploymentInterface(ABC):
             _id: int,
             profile: Profile,
             company: Company,
-            job_title: str) -> Employment:
+            job_title: str,
+            commit=True) -> Employment:
         pass

--- a/services/interfaces/listing_app/job_offer_interface.py
+++ b/services/interfaces/listing_app/job_offer_interface.py
@@ -16,7 +16,8 @@ class JobOfferInterface(ABC):
                          key_responsibilities: str,
                          required_qualifications: str,
                          preferred_qualifications: str,
-                         remote_option: bool) -> JobOffer:
+                         remote_option: bool,
+                         commit=True) -> JobOffer:
         pass
 
     @staticmethod
@@ -51,6 +52,6 @@ class JobOfferInterface(ABC):
                              key_responsibilities: str,
                              required_qualifications: str,
                              preferred_qualifications: str,
-                             remote_option: bool
-                             ) -> JobOffer:
+                             remote_option: bool,
+                             commit=True) -> JobOffer:
         pass

--- a/services/interfaces/listing_app/listing_identifiers_interface.py
+++ b/services/interfaces/listing_app/listing_identifiers_interface.py
@@ -9,7 +9,8 @@ class ListingIdentifiersInterface(ABC):
     @abstractmethod
     def create_listing_identifier(_type: str,
                                   value,
-                                  listing: Listing) -> ListingIdentifiers:
+                                  listing: Listing,
+                                  commit=True) -> ListingIdentifiers:
         pass
 
     @staticmethod
@@ -32,5 +33,6 @@ class ListingIdentifiersInterface(ABC):
     def edit_identifier_by_id(_id: int,
                               _type: str,
                               value,
-                              listing: Listing) -> ListingIdentifiers:
+                              listing: Listing,
+                              commit=True) -> ListingIdentifiers:
         pass

--- a/services/interfaces/listing_app/listing_interface.py
+++ b/services/interfaces/listing_app/listing_interface.py
@@ -9,7 +9,8 @@ class ListingInterface(ABC):
     def create_listing(title: str,
                        location: str,
                        images: str,
-                       description: str) -> Listing:
+                       description: str,
+                       commit=True) -> Listing:
         pass
 
     @staticmethod
@@ -38,6 +39,7 @@ class ListingInterface(ABC):
                            title: str,
                            location: str,
                            images: str,
-                           description: str) -> Listing:
+                           description: str,
+                           commit=True) -> Listing:
         pass
 

--- a/services/interfaces/listing_app/project_interface.py
+++ b/services/interfaces/listing_app/project_interface.py
@@ -10,7 +10,8 @@ class ProjectInterface(ABC):
                        wage: int,
                        preferred_payment: str,
                        status: Project.Status,
-                       estimated_duration: str) -> Project:
+                       estimated_duration: str,
+                       commit=True) -> Project:
         pass
 
     @staticmethod
@@ -39,5 +40,6 @@ class ProjectInterface(ABC):
                            wage: int,
                            preferred_payment: str,
                            status: Project.Status,
-                           estimated_duration: str) -> Project:
+                           estimated_duration: str,
+                           commit=True) -> Project:
         pass

--- a/services/interfaces/shared_app/user_suggestion_interface.py
+++ b/services/interfaces/shared_app/user_suggestion_interface.py
@@ -11,7 +11,8 @@ class UserSuggestionInterface(ABC):
     def create_user_suggestion(field_name: str,
                                suggestion: str,
                                content_type: ContentType,
-                               object_id: int) -> UserSuggestion:
+                               object_id: int,
+                               commit=True) -> UserSuggestion:
         pass
 
     @staticmethod
@@ -35,5 +36,6 @@ class UserSuggestionInterface(ABC):
                                    field_name: str,
                                    suggestion: str,
                                    content_type: ContentType,
-                                   object_id: int) -> UserSuggestion:
+                                   object_id: int,
+                                   commit=True) -> UserSuggestion:
         pass


### PR DESCRIPTION
The commit option when creating objects can be useful because it allows developers to control whether the changes made during the creation process should be immediately saved to the database or only prepared for saving, providing flexibility and preventing unintended changes in the database.